### PR TITLE
Add credential-based authentication with NextAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+*.db

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,18 @@
 				"@fortawesome/free-brands-svg-icons": "^6.5.1",
 				"@fortawesome/free-solid-svg-icons": "^6.5.1",
 				"@fortawesome/react-fontawesome": "^0.2.0",
+				"@prisma/client": "^6.15.0",
 				"autoprefixer": "^10.4.16",
+				"bcryptjs": "^3.0.2",
 				"next": "^14.0.0",
+				"next-auth": "^4.24.11",
 				"postcss": "^8.4.31",
+				"prisma": "^6.15.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-icons": "^4.12.0",
-				"tailwindcss": "^3.3.3"
+				"tailwindcss": "^3.3.3",
+				"ts-node": "^10.9.2"
 			},
 			"devDependencies": {
 				"@types/node": "^20.8.9",
@@ -39,6 +44,37 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.28.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+			"integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -544,6 +580,15 @@
 				"node": ">=12.4.0"
 			}
 		},
+		"node_modules/@panva/hkdf": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+			"integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -552,6 +597,85 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@prisma/client": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.15.0.tgz",
+			"integrity": "sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"peerDependencies": {
+				"prisma": "*",
+				"typescript": ">=5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"prisma": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@prisma/config": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
+			"integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"c12": "3.1.0",
+				"deepmerge-ts": "7.1.5",
+				"effect": "3.16.12",
+				"empathic": "2.0.0"
+			}
+		},
+		"node_modules/@prisma/debug": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
+			"integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@prisma/engines": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
+			"integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@prisma/debug": "6.15.0",
+				"@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+				"@prisma/fetch-engine": "6.15.0",
+				"@prisma/get-platform": "6.15.0"
+			}
+		},
+		"node_modules/@prisma/engines-version": {
+			"version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
+			"integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@prisma/fetch-engine": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
+			"integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@prisma/debug": "6.15.0",
+				"@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+				"@prisma/get-platform": "6.15.0"
+			}
+		},
+		"node_modules/@prisma/get-platform": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
+			"integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@prisma/debug": "6.15.0"
 			}
 		},
 		"node_modules/@rtsao/scc": {
@@ -566,6 +690,12 @@
 			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
 			"integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
 			"license": "MIT"
 		},
 		"node_modules/@swc/counter": {
@@ -583,6 +713,30 @@
 				"@swc/counter": "^0.1.3",
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+			"integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.9.0",
@@ -606,7 +760,6 @@
 			"version": "20.17.50",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz",
 			"integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.19.2"
@@ -1121,7 +1274,6 @@
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
 			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1138,6 +1290,18 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -1477,6 +1641,15 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
+		"node_modules/bcryptjs": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+			"integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+			"license": "BSD-3-Clause",
+			"bin": {
+				"bcrypt": "bin/bcrypt"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1553,6 +1726,71 @@
 			},
 			"engines": {
 				"node": ">=10.16.0"
+			}
+		},
+		"node_modules/c12": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+			"integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^4.0.3",
+				"confbox": "^0.2.2",
+				"defu": "^6.1.4",
+				"dotenv": "^16.6.1",
+				"exsolve": "^1.0.7",
+				"giget": "^2.0.0",
+				"jiti": "^2.4.2",
+				"ohash": "^2.0.11",
+				"pathe": "^2.0.3",
+				"perfect-debounce": "^1.0.0",
+				"pkg-types": "^2.2.0",
+				"rc9": "^2.1.2"
+			},
+			"peerDependencies": {
+				"magicast": "^0.3.5"
+			},
+			"peerDependenciesMeta": {
+				"magicast": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/c12/node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/c12/node_modules/jiti": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+			"integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/c12/node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/call-bind": {
@@ -1697,6 +1935,15 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/citty": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+			"license": "MIT",
+			"dependencies": {
+				"consola": "^3.2.3"
+			}
+		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1735,6 +1982,36 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/confbox": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+			"license": "MIT"
+		},
+		"node_modules/consola": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
@@ -1856,6 +2133,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/deepmerge-ts": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1892,11 +2178,32 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/defu": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+			"license": "MIT"
+		},
+		"node_modules/destr": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+			"integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+			"license": "MIT"
+		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
 			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -1915,6 +2222,18 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -1938,6 +2257,16 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"license": "MIT"
 		},
+		"node_modules/effect": {
+			"version": "3.16.12",
+			"resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
+			"integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"fast-check": "^3.23.1"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.155",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
@@ -1949,6 +2278,15 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"license": "MIT"
+		},
+		"node_modules/empathic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+			"integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/es-abstract": {
 			"version": "1.23.10",
@@ -2594,6 +2932,34 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/exsolve": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+			"integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+			"license": "MIT"
+		},
+		"node_modules/fast-check": {
+			"version": "3.23.2",
+			"resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+			"integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"pure-rand": "^6.1.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2890,6 +3256,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/giget": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+			"integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.1.6",
+				"consola": "^3.4.0",
+				"defu": "^6.1.4",
+				"node-fetch-native": "^1.6.6",
+				"nypm": "^0.6.0",
+				"pathe": "^2.0.3"
+			},
+			"bin": {
+				"giget": "dist/cli.mjs"
 			}
 		},
 		"node_modules/glob": {
@@ -3646,6 +4029,15 @@
 				"jiti": "bin/jiti.js"
 			}
 		},
+		"node_modules/jose": {
+			"version": "4.15.9",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+			"integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3816,6 +4208,12 @@
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"license": "ISC"
 		},
 		"node_modules/math-intrinsics": {
@@ -3991,6 +4389,38 @@
 				}
 			}
 		},
+		"node_modules/next-auth": {
+			"version": "4.24.11",
+			"resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+			"integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+			"license": "ISC",
+			"dependencies": {
+				"@babel/runtime": "^7.20.13",
+				"@panva/hkdf": "^1.0.2",
+				"cookie": "^0.7.0",
+				"jose": "^4.15.5",
+				"oauth": "^0.9.15",
+				"openid-client": "^5.4.0",
+				"preact": "^10.6.3",
+				"preact-render-to-string": "^5.1.19",
+				"uuid": "^8.3.2"
+			},
+			"peerDependencies": {
+				"@auth/core": "0.34.2",
+				"next": "^12.2.5 || ^13 || ^14 || ^15",
+				"nodemailer": "^6.6.5",
+				"react": "^17.0.2 || ^18 || ^19",
+				"react-dom": "^17.0.2 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@auth/core": {
+					"optional": true
+				},
+				"nodemailer": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/next/node_modules/postcss": {
 			"version": "8.4.31",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4019,6 +4449,12 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/node-fetch-native": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+			"integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+			"license": "MIT"
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4042,6 +4478,31 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/nypm": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.1.tgz",
+			"integrity": "sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==",
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.1.6",
+				"consola": "^3.4.2",
+				"pathe": "^2.0.3",
+				"pkg-types": "^2.2.0",
+				"tinyexec": "^1.0.1"
+			},
+			"bin": {
+				"nypm": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": "^14.16.0 || >=16.10.0"
+			}
+		},
+		"node_modules/oauth": {
+			"version": "0.9.15",
+			"resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+			"integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -4174,6 +4635,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/ohash": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+			"license": "MIT"
+		},
+		"node_modules/oidc-token-hash": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+			"integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
+			"license": "MIT",
+			"engines": {
+				"node": "^10.13.0 || >=12.0.0"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4182,6 +4658,42 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/openid-client": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+			"integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+			"license": "MIT",
+			"dependencies": {
+				"jose": "^4.15.9",
+				"lru-cache": "^6.0.0",
+				"object-hash": "^2.2.0",
+				"oidc-token-hash": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/openid-client/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/openid-client/node_modules/object-hash": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/optionator": {
@@ -4316,6 +4828,18 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT"
+		},
+		"node_modules/perfect-debounce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4350,6 +4874,17 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.2.2",
+				"exsolve": "^1.0.7",
+				"pathe": "^2.0.3"
 			}
 		},
 		"node_modules/possible-typed-array-names": {
@@ -4470,6 +5005,28 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"license": "MIT"
 		},
+		"node_modules/preact": {
+			"version": "10.27.1",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+			"integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
+		"node_modules/preact-render-to-string": {
+			"version": "5.2.6",
+			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+			"integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+			"license": "MIT",
+			"dependencies": {
+				"pretty-format": "^3.8.0"
+			},
+			"peerDependencies": {
+				"preact": ">=10"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4478,6 +5035,37 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+			"integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+			"license": "MIT"
+		},
+		"node_modules/prisma": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
+			"integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@prisma/config": "6.15.0",
+				"@prisma/engines": "6.15.0"
+			},
+			"bin": {
+				"prisma": "build/index.js"
+			},
+			"engines": {
+				"node": ">=18.18"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/prop-types": {
@@ -4501,6 +5089,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/pure-rand": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4520,6 +5124,16 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/rc9": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+			"integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+			"license": "MIT",
+			"dependencies": {
+				"defu": "^6.1.4",
+				"destr": "^2.0.3"
+			}
 		},
 		"node_modules/react": {
 			"version": "18.3.1",
@@ -5393,6 +6007,12 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/tinyexec": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+			"integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+			"license": "MIT"
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
@@ -5468,6 +6088,55 @@
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-node/node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"license": "MIT"
 		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.15.0",
@@ -5596,7 +6265,6 @@
 			"version": "5.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5629,7 +6297,6 @@
 			"version": "6.19.8",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unrs-resolver": {
@@ -5709,6 +6376,21 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"license": "MIT"
 		},
 		"node_modules/which": {
@@ -5926,6 +6608,12 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"license": "ISC"
+		},
 		"node_modules/yaml": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
@@ -5936,6 +6624,15 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,32 +1,40 @@
 {
-	"name": "client-page-template",
-	"version": "1.0.0",
-	"private": true,
-	"scripts": {
-		"dev": "next dev",
-		"build": "next build",
-		"start": "next start -H 0.0.0.0 -p 3000",
-		"lint": "next lint"
-	},
-	"dependencies": {
-		"@fortawesome/fontawesome-svg-core": "^6.5.1",
-		"@fortawesome/free-brands-svg-icons": "^6.5.1",
-		"@fortawesome/free-solid-svg-icons": "^6.5.1",
-		"@fortawesome/react-fontawesome": "^0.2.0",
-		"autoprefixer": "^10.4.16",
-		"next": "^14.0.0",
-		"postcss": "^8.4.31",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
-		"react-icons": "^4.12.0",
-		"tailwindcss": "^3.3.3"
-	},
-	"devDependencies": {
-		"@types/node": "^20.8.9",
-		"@types/react": "^18.2.33",
-		"@types/react-dom": "^18.2.14",
-		"eslint": "^8.52.0",
-		"eslint-config-next": "^14.0.0",
-		"typescript": "^5.2.2"
-	}
+        "name": "client-page-template",
+        "version": "1.0.0",
+        "private": true,
+        "scripts": {
+                "dev": "next dev",
+                "build": "next build",
+                "start": "next start -H 0.0.0.0 -p 3000",
+                "lint": "next lint"
+        },
+        "dependencies": {
+                "@fortawesome/fontawesome-svg-core": "^6.5.1",
+                "@fortawesome/free-brands-svg-icons": "^6.5.1",
+                "@fortawesome/free-solid-svg-icons": "^6.5.1",
+                "@fortawesome/react-fontawesome": "^0.2.0",
+                "@prisma/client": "^6.15.0",
+                "autoprefixer": "^10.4.16",
+                "bcryptjs": "^3.0.2",
+                "next": "^14.0.0",
+                "next-auth": "^4.24.11",
+                "postcss": "^8.4.31",
+                "prisma": "^6.15.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0",
+                "react-icons": "^4.12.0",
+                "tailwindcss": "^3.3.3"
+        },
+        "devDependencies": {
+                "@types/node": "^20.8.9",
+                "@types/react": "^18.2.33",
+                "@types/react-dom": "^18.2.14",
+                "eslint": "^8.52.0",
+                "eslint-config-next": "^14.0.0",
+                "ts-node": "^10.9.2",
+                "typescript": "^5.2.2"
+        },
+        "prisma": {
+                "seed": "node prisma/seed.js"
+        }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,21 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum Role {
+  SUPER_ADMIN
+  ADMIN
+  USER
+}
+
+model User {
+  id           Int    @id @default(autoincrement())
+  email        String @unique
+  passwordHash String
+  role         Role   @default(USER)
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,27 @@
+const { PrismaClient, Role } = require('@prisma/client');
+const bcrypt = require('bcryptjs');
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = 'superadmin@example.com';
+  const password = 'superadmin';
+  const passwordHash = await bcrypt.hash(password, 10);
+  await prisma.user.upsert({
+    where: { email },
+    update: {},
+    create: {
+      email,
+      passwordHash,
+      role: Role.SUPER_ADMIN,
+    },
+  });
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,27 @@
+import { PrismaClient, Role } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = 'superadmin@example.com';
+  const password = 'superadmin';
+  const passwordHash = await bcrypt.hash(password, 10);
+  await prisma.user.upsert({
+    where: { email },
+    update: {},
+    create: {
+      email,
+      passwordHash,
+      role: Role.SUPER_ADMIN,
+    },
+  });
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await signIn("credentials", {
+      email,
+      password,
+      redirect: false,
+    });
+    if (res?.error) {
+      setError("Invalid credentials");
+    } else {
+      router.push("/");
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="border p-2"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-2"
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="p-2 bg-blue-500 text-white">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(auth)/logout/page.tsx
+++ b/src/app/(auth)/logout/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+import { signOut } from "next-auth/react";
+
+export default function LogoutPage() {
+  useEffect(() => {
+    signOut({ callbackUrl: "/" });
+  }, []);
+  return <p>Logging out...</p>;
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,57 @@
+import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+const authOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) {
+          return null;
+        }
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email },
+        });
+        if (!user) {
+          return null;
+        }
+        const isValid = await bcrypt.compare(
+          credentials.password,
+          user.passwordHash
+        );
+        if (!isValid) {
+          return null;
+        }
+        return { id: String(user.id), email: user.email, role: user.role };
+      },
+    }),
+  ],
+  session: {
+    strategy: "jwt" as const,
+  },
+  callbacks: {
+    async jwt({ token, user }: { token: any; user?: any }) {
+      if (user) {
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }: { session: any; token: any }) {
+      if (session.user) {
+        (session.user as any).role = token.role as string;
+      }
+      return session;
+    },
+  },
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { signIn } from "next-auth/react";
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json();
+  const res = await signIn("credentials", {
+    email,
+    password,
+    redirect: false,
+  });
+  if (res?.error) {
+    return NextResponse.json({ error: res.error }, { status: 401 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,23 @@
+import { withAuth } from "next-auth/middleware";
+import { NextResponse } from "next/server";
+
+export default withAuth(
+  function middleware(req) {
+    const token = req.nextauth.token;
+    if (req.nextUrl.pathname.startsWith("/admin")) {
+      if (token?.role !== "ADMIN" && token?.role !== "SUPER_ADMIN") {
+        return NextResponse.redirect(new URL("/(auth)/login", req.url));
+      }
+    }
+    return NextResponse.next();
+  },
+  {
+    callbacks: {
+      authorized: ({ token }) => !!token,
+    },
+  }
+);
+
+export const config = {
+  matcher: ["/admin/:path*"]
+};

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,18 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultSession["user"] & {
+      role?: string;
+    };
+  }
+  interface User {
+    role?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- Integrate NextAuth using credentials provider and Prisma-backed users
- Add login/logout pages and API routes for credential-based auth
- Seed default super admin and enforce role-based access via middleware

## Testing
- `npx prisma generate`
- `npx prisma db push`
- `npx prisma db seed`
- `npm run build` *(client-data route logged missing environment variable but build completed)*

------
https://chatgpt.com/codex/tasks/task_b_68ba09013888832389862ee513314253