### PR TITLE
Add theme toggling and reusable UI components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+dist
+npm-debug.log*
+yarn-error.log*

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@fortawesome/free-brands-svg-icons": "^6.5.1",
 				"@fortawesome/free-solid-svg-icons": "^6.5.1",
 				"@fortawesome/react-fontawesome": "^0.2.0",
+				"@radix-ui/react-switch": "^1.2.6",
 				"autoprefixer": "^10.4.16",
 				"next": "^14.0.0",
 				"postcss": "^8.4.31",
@@ -554,6 +555,197 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+			"integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+			"integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-switch": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+			"integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+			"integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-effect-event": "0.0.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+			"integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+			"integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-previous": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+			"integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-size": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+			"integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -616,14 +808,14 @@
 			"version": "15.7.14",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
 			"integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
 			"version": "18.3.22",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.22.tgz",
 			"integrity": "sha512-vUhG0YmQZ7kL/tmKLrD3g5zXbXXreZXB3pmROW8bg3CnLnpjkRVwUlLne7Ufa2r9yJ8+/6B73RzhAek5TBKh2Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -634,7 +826,7 @@
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
@@ -1767,7 +1959,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"@fortawesome/free-brands-svg-icons": "^6.5.1",
 		"@fortawesome/free-solid-svg-icons": "^6.5.1",
 		"@fortawesome/react-fontawesome": "^0.2.0",
+		"@radix-ui/react-switch": "^1.2.6",
 		"autoprefixer": "^10.4.16",
 		"next": "^14.0.0",
 		"postcss": "^8.4.31",

--- a/src/app/components/ContactForm.tsx
+++ b/src/app/components/ContactForm.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { useState } from 'react';
+import Input from './ui/Input';
+import Button from './ui/Button';
+
+export default function ContactForm() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log(form);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="w-full flex flex-col gap-4 mt-6"
+      aria-label="contact form"
+    >
+      <Input
+        label="Name"
+        name="name"
+        value={form.name}
+        onChange={handleChange}
+      />
+      <Input
+        label="Email"
+        type="email"
+        name="email"
+        value={form.email}
+        onChange={handleChange}
+      />
+      <div className="flex flex-col w-full">
+        <label htmlFor="message" className="mb-1 text-sm font-medium text-[var(--text-dark)]">
+          Message
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          className="border border-[var(--border-color)] rounded-md p-2 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-[var(--highlight)]"
+          value={form.message}
+          onChange={handleChange}
+          aria-label="Message"
+        />
+      </div>
+      <Button type="submit" aria-label="Submit contact form">
+        Send
+      </Button>
+    </form>
+  );
+}

--- a/src/app/components/ContactInfoList.tsx
+++ b/src/app/components/ContactInfoList.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from './types';
+import { getIcon } from './iconUtils';
+import SocialCard from './SocialCard';
+
+export default function ContactInfoList({ links }: { links: Link[] }) {
+  return (
+    <>
+      {links.map((link, index) => (
+        <SocialCard
+          key={index}
+          icon={getIcon(link.icon)}
+          text={link.title}
+          link={link.url}
+          className="contact-info"
+        />
+      ))}
+    </>
+  );
+}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Footer() {
+  return <div className="footer">©️ 2025 by Osiris Labs</div>;
+}

--- a/src/app/components/IconLinksRow.tsx
+++ b/src/app/components/IconLinksRow.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Link } from './types';
+import { getIcon } from './iconUtils';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export default function IconLinksRow({ links }: { links: Link[] }) {
+  return (
+    <div className="icons">
+      {links.map((link, index) => (
+        <a
+          key={index}
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={link.title}
+          className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--highlight)]"
+        >
+          <FontAwesomeIcon icon={getIcon(link.icon)} />
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/app/components/Logo.tsx
+++ b/src/app/components/Logo.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Logo({ src, alt }: { src: string; alt: string }) {
+  return (
+    <div className="logo">
+      <img src={src} alt={alt} />
+    </div>
+  );
+}

--- a/src/app/components/SocialCard.tsx
+++ b/src/app/components/SocialCard.tsx
@@ -3,32 +3,35 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 
 interface SocialCardProps {
-	icon: IconDefinition;
-	text: string;
-	link: string;
-	subText?: string;
+  icon: IconDefinition;
+  text: string;
+  link: string;
+  subText?: string;
+  className?: string;
 }
 
 export default function SocialCard({
-	icon,
-	text,
-	link,
-	subText,
+  icon,
+  text,
+  link,
+  subText,
+  className = '',
 }: SocialCardProps) {
-	return (
-		<a
-			href={link}
-			target="_blank"
-			rel="noopener noreferrer"
-			className="social-card"
-		>
-			<FontAwesomeIcon icon={icon} className="social-card-icon" />
-			<span className="social-card-text">
-				{text}
-				{subText && <br />}
-				{subText}
-			</span>
-			<FontAwesomeIcon icon={faEllipsisV} className="dots" />
-		</a>
-	);
+  return (
+    <a
+      href={link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`social-card w-full ${className} focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--highlight)]`}
+      aria-label={text}
+    >
+      <FontAwesomeIcon icon={icon} className="social-card-icon" />
+      <span className="social-card-text">
+        {text}
+        {subText && <br />}
+        {subText}
+      </span>
+      <FontAwesomeIcon icon={faEllipsisV} className="dots" />
+    </a>
+  );
 }

--- a/src/app/components/SocialLinksList.tsx
+++ b/src/app/components/SocialLinksList.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from './types';
+import { getIcon } from './iconUtils';
+import SocialCard from './SocialCard';
+
+export default function SocialLinksList({ links }: { links: Link[] }) {
+  return (
+    <>
+      {links.map((link, index) => (
+        <SocialCard
+          key={index}
+          icon={getIcon(link.icon)}
+          text={link.displayTitle || link.title}
+          link={link.url}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/app/components/ThemeProvider.tsx
+++ b/src/app/components/ThemeProvider.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  // Read theme from cookie on mount
+  useEffect(() => {
+    const match = document.cookie.match(/theme=(light|dark)/);
+    const initial = (match ? (match[1] as Theme) : 'light');
+    setTheme(initial);
+    document.documentElement.classList.toggle('dark', initial === 'dark');
+  }, []);
+
+  // Persist theme to cookie and html class
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.cookie = `theme=${theme}; path=/; max-age=31536000`;
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import * as Switch from '@radix-ui/react-switch';
+import { useTheme } from './ThemeProvider';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <div className="flex justify-end mb-4">
+      <label className="sr-only" htmlFor="theme-toggle">
+        Toggle dark mode
+      </label>
+      <Switch.Root
+        id="theme-toggle"
+        checked={theme === 'dark'}
+        onCheckedChange={toggleTheme}
+        className="w-12 h-6 bg-gray-200 dark:bg-gray-700 rounded-full relative focus:outline-none focus:ring-2 focus:ring-[var(--highlight)]"
+        aria-label="Toggle dark mode"
+      >
+        <Switch.Thumb className="block w-5 h-5 bg-white rounded-full shadow transition-transform translate-x-0.5 data-[state=checked]:translate-x-[22px]" />
+      </Switch.Root>
+    </div>
+  );
+}

--- a/src/app/components/Title.tsx
+++ b/src/app/components/Title.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Title({ text }: { text: string }) {
+  return <h1>{text}</h1>;
+}

--- a/src/app/components/iconUtils.ts
+++ b/src/app/components/iconUtils.ts
@@ -1,0 +1,50 @@
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faPhone,
+  faEnvelope,
+  faGlobe,
+  faMapMarkerAlt,
+  faUtensils,
+  faShoppingBag,
+  faShoppingCart,
+  faStore,
+  faCalendar,
+  faClock,
+  faInfoCircle,
+  faLink,
+} from '@fortawesome/free-solid-svg-icons';
+import {
+  faInstagram,
+  faFacebook,
+  faTwitter,
+  faLinkedin,
+  faYoutube,
+  faTiktok,
+} from '@fortawesome/free-brands-svg-icons';
+
+const iconMap: Record<string, IconDefinition> = {
+  phone: faPhone,
+  email: faEnvelope,
+  envelope: faEnvelope,
+  website: faGlobe,
+  map: faMapMarkerAlt,
+  instagram: faInstagram,
+  facebook: faFacebook,
+  twitter: faTwitter,
+  linkedin: faLinkedin,
+  youtube: faYoutube,
+  tiktok: faTiktok,
+  menu: faUtensils,
+  shop: faShoppingBag,
+  cart: faShoppingCart,
+  store: faStore,
+  calendar: faCalendar,
+  clock: faClock,
+  info: faInfoCircle,
+  link: faLink,
+};
+
+export const getIcon = (name: string): IconDefinition => iconMap[name] || faLink;
+
+export const isContactIcon = (name: string): boolean =>
+  ['phone', 'email', 'envelope', 'website', 'map'].includes(name);

--- a/src/app/components/types.ts
+++ b/src/app/components/types.ts
@@ -1,0 +1,20 @@
+export interface Link {
+  title: string;
+  url: string;
+  icon: string;
+  displayTitle?: string;
+}
+
+export interface ClientData {
+  name: string;
+  logo: string;
+  description?: string;
+  links: Link[];
+  customization?: {
+    backgroundColor?: string;
+    textColor?: string;
+    buttonStyle?: string;
+    font?: string;
+    accentColor?: string;
+  };
+}

--- a/src/app/components/ui/Button.tsx
+++ b/src/app/components/ui/Button.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export default function Button({ children, className = '', ...props }: ButtonProps) {
+  return (
+    <button
+      className={`px-4 py-2 rounded-md bg-[var(--highlight)] text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--highlight)] ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/components/ui/Input.tsx
+++ b/src/app/components/ui/Input.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import React from 'react';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export default function Input({ label, id, ...props }: InputProps) {
+  const inputId = id || label.toLowerCase().replace(/\s+/g, '-');
+  return (
+    <div className="flex flex-col w-full">
+      <label htmlFor={inputId} className="mb-1 text-sm font-medium text-[var(--text-dark)]">
+        {label}
+      </label>
+      <input
+        id={inputId}
+        className="border border-[var(--border-color)] rounded-md p-2 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-[var(--highlight)]"
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,14 @@
   --highlight: #2688a8;
 }
 
+.dark {
+  --primary-bg: #1f2937;
+  --card-bg: #374151;
+  --border-color: #4b5563;
+  --text-dark: #f3f4f6;
+  --highlight: #0ea5e9;
+}
+
 body {
   margin: 0;
   font-family: 'Space Mono', monospace;
@@ -107,8 +115,8 @@ a:hover {
   }
 
   .social-card {
-    @apply bg-[var(--card-bg)] border border-[var(--border-color)] rounded-[25px] p-[14px_20px] 
-    flex items-center justify-between my-3 shadow-sm transition-all duration-300 no-underline 
+    @apply w-full bg-[var(--card-bg)] border border-[var(--border-color)] rounded-[25px] p-[14px_20px]
+    flex items-center justify-between my-3 shadow-sm transition-all duration-300 no-underline
     text-[var(--text-dark)] hover:bg-[#dff3f9] hover:translate-y-[-2px] hover:shadow-md;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { ThemeProvider } from './components/ThemeProvider';
 
 // export const metadata: Metadata = {
 // 	title: ,
@@ -33,7 +34,9 @@ export default function RootLayout({
 					href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
 				/>
 			</head>
-			<body>{children}</body>
-		</html>
-	);
+                        <body>
+                                <ThemeProvider>{children}</ThemeProvider>
+                        </body>
+                </html>
+        );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,181 +1,64 @@
 'use client';
 
 import React from 'react';
-
-interface Link {
-	title: string;
-	url: string;
-	icon: string;
-	displayTitle?: string;
-}
-
-interface ClientData {
-	name: string;
-	logo: string;
-	description?: string;
-	links: Link[];
-	customization?: {
-		backgroundColor?: string;
-		textColor?: string;
-		buttonStyle?: string;
-		font?: string;
-		accentColor?: string;
-	};
-}
+import { ClientData } from './components/types';
+import { isContactIcon } from './components/iconUtils';
+import Logo from './components/Logo';
+import Title from './components/Title';
+import IconLinksRow from './components/IconLinksRow';
+import SocialLinksList from './components/SocialLinksList';
+import ContactInfoList from './components/ContactInfoList';
+import Footer from './components/Footer';
+import ThemeToggle from './components/ThemeToggle';
+import ContactForm from './components/ContactForm';
 
 const defaultData: ClientData = {
-	name: 'Test Data',
-	logo: 'https://sandybrown-ant-159541.hostingersite.com/wp-content/uploads/2025/05/Dr.-Nahla-02.png',
-	links: [],
-};
-
-// Icon mapping function to convert icon names to Font Awesome classes
-const getIconClass = (
-	iconName: string
-): { className: string; prefix: string } => {
-	const iconMap: Record<string, { className: string; prefix: string }> = {
-		// Contact icons
-		phone: { className: 'fa-phone', prefix: 'fas' },
-		email: { className: 'fa-envelope', prefix: 'fas' },
-		envelope: { className: 'fa-envelope', prefix: 'fas' }, // backward compatibility
-		website: { className: 'fa-globe', prefix: 'fas' },
-		map: { className: 'fa-map-marker-alt', prefix: 'fas' },
-
-		// Social media icons
-		instagram: { className: 'fa-instagram', prefix: 'fab' },
-		facebook: { className: 'fa-facebook', prefix: 'fab' },
-		twitter: { className: 'fa-twitter', prefix: 'fab' },
-		linkedin: { className: 'fa-linkedin', prefix: 'fab' },
-		youtube: { className: 'fa-youtube', prefix: 'fab' },
-		tiktok: { className: 'fa-tiktok', prefix: 'fab' },
-
-		// Business icons
-		menu: { className: 'fa-utensils', prefix: 'fas' },
-		shop: { className: 'fa-shopping-bag', prefix: 'fas' },
-		cart: { className: 'fa-shopping-cart', prefix: 'fas' },
-		store: { className: 'fa-store', prefix: 'fas' },
-		calendar: { className: 'fa-calendar', prefix: 'fas' },
-		clock: { className: 'fa-clock', prefix: 'fas' },
-		info: { className: 'fa-info-circle', prefix: 'fas' },
-		link: { className: 'fa-link', prefix: 'fas' },
-	};
-
-	return iconMap[iconName] || { className: 'fa-link', prefix: 'fas' };
-};
-
-// Check if icon should be displayed in the top icons row
-const isContactIcon = (iconName: string): boolean => {
-	return ['phone', 'email', 'envelope', 'website'].includes(iconName);
+  name: 'Test Data',
+  logo: 'https://sandybrown-ant-159541.hostingersite.com/wp-content/uploads/2025/05/Dr.-Nahla-02.png',
+  links: [],
 };
 
 export default function Page() {
-	// Check if custom HTML is provided (Base64 encoded)
-	const customHTMLBase64 = process.env.NEXT_PUBLIC_CUSTOM_HTML_BASE64;
+  const customHTMLBase64 = process.env.NEXT_PUBLIC_CUSTOM_HTML_BASE64;
 
-	// If custom HTML is provided, decode and render it directly
-	if (customHTMLBase64) {
-		try {
-			// Decode the Base64 HTML
-			const customHTML = Buffer.from(customHTMLBase64, 'base64').toString(
-				'utf8'
-			);
-			return (
-				<div
-					dangerouslySetInnerHTML={{ __html: customHTML }}
-					style={{ width: '100%', height: '100vh' }}
-				/>
-			);
-		} catch (error) {
-			console.error('Error decoding custom HTML:', error);
-			// Fall back to template mode if decoding fails
-		}
-	}
+  if (customHTMLBase64) {
+    try {
+      const customHTML = Buffer.from(customHTMLBase64, 'base64').toString('utf8');
+      return (
+        <div
+          dangerouslySetInnerHTML={{ __html: customHTML }}
+          style={{ width: '100%', height: '100vh' }}
+        />
+      );
+    } catch (error) {
+      console.error('Error decoding custom HTML:', error);
+    }
+  }
 
-	// Parse the client data from environment variable for template mode
-	const clientData: ClientData = (() => {
-		try {
-			const envData = process.env.NEXT_PUBLIC_CLIENT_DATA;
-			if (!envData) return defaultData;
-			return JSON.parse(envData);
-		} catch (error) {
-			console.error('Error parsing client data:', error);
-			return defaultData;
-		}
-	})();
+  const clientData: ClientData = (() => {
+    try {
+      const envData = process.env.NEXT_PUBLIC_CLIENT_DATA;
+      if (!envData) return defaultData;
+      return JSON.parse(envData);
+    } catch (error) {
+      console.error('Error parsing client data:', error);
+      return defaultData;
+    }
+  })();
 
-	return (
-		<div className="container">
-			{/* LOGO */}
-			<div className="logo">
-				<img src={clientData.logo} alt={`${clientData.name} Logo`} />
-			</div>
+  const contactLinks = clientData.links.filter((link) => isContactIcon(link.icon));
+  const socialLinks = clientData.links.filter((link) => !isContactIcon(link.icon));
 
-			{/* TITLE */}
-			<h1>{clientData.name}</h1>
-
-			{/* ICON LINKS ROW */}
-			<div className="icons">
-				{clientData.links
-					.filter((link) => isContactIcon(link.icon))
-					.map((link, index) => {
-						const iconClass = getIconClass(link.icon);
-						return (
-							<a
-								key={index}
-								href={link.url}
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								<i
-									className={`${iconClass.prefix} ${iconClass.className}`}
-								></i>
-							</a>
-						);
-					})}
-			</div>
-
-			{/* SOCIAL CARDS */}
-			{clientData.links
-				.filter((link) => !isContactIcon(link.icon))
-				.map((link, index) => {
-					const iconClass = getIconClass(link.icon);
-					return (
-						<a
-							key={index}
-							href={link.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="social-card"
-						>
-							<i
-								className={`${iconClass.prefix} ${iconClass.className}`}
-							></i>
-							<span>{link.displayTitle || link.title}</span>
-							<i className="fas fa-ellipsis-v dots"></i>
-						</a>
-					);
-				})}
-
-			{/* CONTACT INFO */}
-			{clientData.links
-				.filter((link) => isContactIcon(link.icon))
-				.map((link, index) => {
-					const iconClass = getIconClass(link.icon);
-					return (
-						<div key={index} className="social-card contact-info">
-							<i
-								className={`${iconClass.prefix} ${iconClass.className}`}
-							></i>
-							<span>
-								<a href={link.url}>{link.title}</a>
-							</span>
-							<i className="fas fa-ellipsis-v dots"></i>
-						</div>
-					);
-				})}
-
-			{/* FOOTER */}
-			<div className="footer">©️ 2025 by Osiris Labs</div>
-		</div>
-	);
+  return (
+    <div className="container">
+      <ThemeToggle />
+      <Logo src={clientData.logo} alt={`${clientData.name} Logo`} />
+      <Title text={clientData.name} />
+      <IconLinksRow links={contactLinks} />
+      <SocialLinksList links={socialLinks} />
+      <ContactInfoList links={contactLinks} />
+      <ContactForm />
+      <Footer />
+    </div>
+  );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-	content: [
-		'./src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-		'./src/components/**/*.{js,ts,jsx,tsx,mdx}',
-		'./src/app/**/*.{js,ts,jsx,tsx,mdx}',
-	],
+        darkMode: 'class',
+        content: [
+                './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+                './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+                './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+        ],
 	theme: {
 		extend: {
 			animation: {


### PR DESCRIPTION
## Summary
- Introduce ThemeProvider with cookie-based light/dark mode and Tailwind dark mode configuration
- Refactor page into modular components with Tailwind-styled buttons, inputs, and social cards
- Add Radix UI switch for theme toggle and accessible contact form

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: interactive configuration)


------
https://chatgpt.com/codex/tasks/task_b_68ba09097e448323a01b2288c2f41d3d